### PR TITLE
Remove leading space from keywords.txt identifier token

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,27 +5,27 @@
 #######################################
 # Library (KEYWORD3)
 #######################################
-smeNfcDriver	    KEYWORD3
-smeNfc	            KEYWORD3
+smeNfcDriver	KEYWORD3
+smeNfc	KEYWORD3
 
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-RecordPosEnu	 KEYWORD1
-NDEFDataStr	 KEYWORD1
+RecordPosEnu	KEYWORD1
+NDEFDataStr	KEYWORD1
 
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 storeUrihttp	KEYWORD2
-storeText	    KEYWORD2
-readManufacturingData	    KEYWORD2
-readUID	    KEYWORD2
-readUserPage	    KEYWORD2
-writeUserPage	    KEYWORD2
+storeText	KEYWORD2
+readManufacturingData	KEYWORD2
+readUID	KEYWORD2
+readUserPage	KEYWORD2
+writeUserPage	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-NFC_PAGE_SIZE	 LITERAL1
+NFC_PAGE_SIZE	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. Leading spaces on a keyword identifier causes it to not be recognized by the Arduino IDE. On Arduino IDE 1.6.5 and newer an unrecognized keyword identifier causes the default editor.function.style highlighting to be used (as with KEYWORD2, KEYWORD3, LITERAL2).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords